### PR TITLE
Add Transcribe Command Functionality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,17 @@
 {
   "name": "scene-keeper",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scene-keeper",
+      "version": "1.0.0",
       "dependencies": {
         "@hono/node-server": "^1.19.2",
         "discord-interactions": "^4.3.0",
-        "hono": "^4.9.7"
+        "hono": "^4.9.7",
+        "resend": "^6.2.2"
       },
       "devDependencies": {
         "@eslint/js": "^9.35.0",
@@ -721,6 +724,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1200,6 +1209,12 @@
         "node": ">=18.4.0"
       }
     },
+    "node_modules/es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+      "license": "MIT"
+    },
     "node_modules/esbuild": {
       "version": "0.25.9",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.9.tgz",
@@ -1476,6 +1491,12 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
     },
     "node_modules/fastq": {
       "version": "1.19.1",
@@ -1982,6 +2003,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "license": "MIT"
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -2002,6 +2029,32 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT"
+    },
+    "node_modules/resend": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.2.2.tgz",
+      "integrity": "sha512-EF/wUj0y/CHBDqLV9iKrNHxGV/wdJfzfEzhPbd3tXD4wtMssabgVwys7N3dv+s1EsqnXjC0uN6ylpfvWTzF4Aw==",
+      "license": "MIT",
+      "dependencies": {
+        "svix": "1.76.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@react-email/render": "*"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
+      }
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
@@ -2120,6 +2173,29 @@
         "node": ">=8"
       }
     },
+    "node_modules/svix": {
+      "version": "1.76.1",
+      "resolved": "https://registry.npmjs.org/svix/-/svix-1.76.1.tgz",
+      "integrity": "sha512-CRuDWBTgYfDnBLRaZdKp9VuoPcNUq9An14c/k+4YJ15Qc5Grvf66vp0jvTltd4t7OIRj+8lM1DAgvSgvf7hdLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "@types/node": "^22.7.5",
+        "es6-promise": "^4.2.8",
+        "fast-sha256": "^1.3.0",
+        "url-parse": "^1.5.10",
+        "uuid": "^10.0.0"
+      }
+    },
+    "node_modules/svix/node_modules/@types/node": {
+      "version": "22.18.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.12.tgz",
+      "integrity": "sha512-BICHQ67iqxQGFSzfCFTT7MRQ5XcBjG5aeKh5Ok38UBbPe5fxTyE+aHFxwVrGyr8GNlqFMLKD1D3P2K/1ks8tog==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -2221,7 +2297,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/uri-js": {
@@ -2232,6 +2307,29 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "@hono/node-server": "^1.19.2",
     "discord-interactions": "^4.3.0",
-    "hono": "^4.9.7"
+    "hono": "^4.9.7",
+    "resend": "^6.2.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.35.0",

--- a/src/commands/development/commandList.ts
+++ b/src/commands/development/commandList.ts
@@ -26,10 +26,10 @@ const clean: ApplicationCommand = {
   default_member_permissions: (0x800 | 0x2000 | 0x400000000).toString(), // Set the permissions a user must have to use it.
 };
 
-const archive: ApplicationCommand = {
+const transcribe: ApplicationCommand = {
   version: '1',
   type: 1, // 1 is a slash command
-  name: 'archive',
+  name: 'transcribe',
   description: 'Send all channel messages to the email addresses specified.',
   application_id: process.env.APP_ID || 'missing_app_id',
   default_member_permissions: (0x800 | 0x4000000000).toString(), // Set the permissions a user must have to use it.
@@ -37,10 +37,10 @@ const archive: ApplicationCommand = {
     {
       type: 3, // STRING type
       name: 'email_list',
-      description: 'Comma separated email addresses to send the archive to.',
+      description: 'Comma separated email addresses to send the transcription to.',
       required: true,
     },
   ],
 };
 
-export const devCommandList: ApplicationCommand[] = [testCommand, clean, archive];
+export const devCommandList: ApplicationCommand[] = [testCommand, clean, transcribe];

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import { Hono } from 'hono';
 import { InteractionType, InteractionResponseType } from 'discord-interactions';
 import { verifyKeyMiddleware } from './middleware/verifyKey.js';
 import { cleanChannel } from './lib/cleanFunctions.js';
-import { archiveChannel } from './lib/archiveFunctions.js';
+import { transcribeChannel } from './lib/transcribeFunctions.js';
 
 const app = new Hono();
 
@@ -52,7 +52,7 @@ app.post('/interactions', verifyKeyMiddleware, async (ctx) => {
       });
     }
 
-    if (data.name === 'archive') {
+    if (data.name === 'transcribe') {
       // console.log(`req: ${JSON.stringify(await ctx.req.json(), null, 2)}`);
       const emailListObject: { name: string; type: number; value: string } | undefined =
         data.options.find(
@@ -66,7 +66,7 @@ app.post('/interactions', verifyKeyMiddleware, async (ctx) => {
         return ctx.json({
           type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
           data: {
-            content: `Archive command received from user ${member.user.username}! But no email recipients were provided.`,
+            content: `Transcribe command received from user ${member.user.username}! But no email recipients were provided.`,
           },
         });
       }
@@ -74,8 +74,8 @@ app.post('/interactions', verifyKeyMiddleware, async (ctx) => {
       // Split the comma-separated email list into an array and trim whitespace
       const emailRecipients = emailListObject.value.split(',').map((email: string) => email.trim());
 
-      // Call the archiveChannel function to process the channel archiving in the background
-      archiveChannel(
+      // Call the transcribeChannel function to process the channel archiving in the background
+      transcribeChannel(
         guild_id,
         { id: channel.id, name: channel.name },
         { id: member.user.id, username: member.user.username },
@@ -86,7 +86,7 @@ app.post('/interactions', verifyKeyMiddleware, async (ctx) => {
       return ctx.json({
         type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
         data: {
-          content: `Archive command received from user ${member.user.username}! Preparing to email message log.`,
+          content: `Transcribe command received from user ${member.user.username}! Preparing to email message log.`,
         },
       });
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { Hono } from 'hono';
 import { InteractionType, InteractionResponseType } from 'discord-interactions';
 import { verifyKeyMiddleware } from './middleware/verifyKey.js';
 import { cleanChannel } from './lib/cleanFunctions.js';
+import { archiveChannel } from './lib/archiveFunctions.js';
 
 const app = new Hono();
 
@@ -16,7 +17,7 @@ app.get('/interactions', (ctx) => {
 
 app.post('/interactions', verifyKeyMiddleware, async (ctx) => {
   // Handle the interaction here
-  const { id, type, member, data, channel } = await ctx.req.json();
+  const { guild_id, type, member, data, channel } = await ctx.req.json();
 
   if (type === InteractionType.PING) {
     ctx.status(200);
@@ -47,6 +48,45 @@ app.post('/interactions', verifyKeyMiddleware, async (ctx) => {
         type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
         data: {
           content: `Clean command received from user ${member.user.username}! Preparing to clear non-pinned messages.`,
+        },
+      });
+    }
+
+    if (data.name === 'archive') {
+      // console.log(`req: ${JSON.stringify(await ctx.req.json(), null, 2)}`);
+      const emailListObject: { name: string; type: number; value: string } | undefined =
+        data.options.find(
+          (option: { name: string; type: number; value: string }) => option.name === 'email_list'
+        );
+
+      // If no email list provided, respond with an error message
+      // Discord should have prevented this from happening since it's a required option
+      // but just in case...
+      if (!emailListObject) {
+        return ctx.json({
+          type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
+          data: {
+            content: `Archive command received from user ${member.user.username}! But no email recipients were provided.`,
+          },
+        });
+      }
+
+      // Split the comma-separated email list into an array and trim whitespace
+      const emailRecipients = emailListObject.value.split(',').map((email: string) => email.trim());
+
+      // Call the archiveChannel function to process the channel archiving in the background
+      archiveChannel(
+        guild_id,
+        { id: channel.id, name: channel.name },
+        { id: member.user.id, username: member.user.username },
+        emailRecipients
+      );
+
+      // Acknowledge the command and inform the user that the bot is processing it.
+      return ctx.json({
+        type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
+        data: {
+          content: `Archive command received from user ${member.user.username}! Preparing to email message log.`,
         },
       });
     }

--- a/src/lib/archiveFunctions.ts
+++ b/src/lib/archiveFunctions.ts
@@ -1,0 +1,246 @@
+import type { Message } from '@/types/message.js';
+
+import packageJson from '../../package.json' with { type: 'json' };
+import { Resend } from 'resend';
+import { rateLimitedFetch } from './sharedFunctions.js';
+
+const baseUrl = 'https://discord.com/api/v10/';
+const discordBotUserAgent = `DiscordBot (https://github.com/jeffinnes/scene-keeper, ${packageJson.version})`;
+
+async function archiveChannel(
+  guildID: string,
+  channel: { id: string; name: string },
+  user: { id: string; username: string },
+  emailRecipients: string[]
+) {
+  try {
+    // ToDo Delete debug logging when done
+    console.log(
+      `Sending channel archive for: ${channel.name} (ID: ${channel.id}) requested by user ${user.username}`
+    );
+
+    // Fetch guild name for email context
+    const guildNameResponse = await rateLimitedFetch(`${baseUrl}guilds/${guildID}`, {
+      headers: {
+        Authorization: `Bot ${process.env.DISCORD_TOKEN}`,
+        'Content-Type': 'application/json; charset=UTF-8',
+        'User-Agent': discordBotUserAgent,
+      },
+    });
+
+    if (!guildNameResponse.ok) {
+      throw new Error(
+        `Failed to fetch guild name: ${guildNameResponse.status} ${guildNameResponse.statusText}`
+      );
+    }
+
+    const guildInfo: { name: string; id: string } = await guildNameResponse.json();
+
+    const messageLimit = 100; // Discord API message limit per request (100 max, set lower for debugging with low use channels)
+
+    const messagesToArchive: Message[] = [];
+
+    let flag = true;
+
+    while (flag === true) {
+      // Fetch all the channel messages
+      const getMessagesUrl = `${baseUrl}channels/${channel.id}/messages?limit=${messageLimit}${
+        messagesToArchive.length > 0
+          ? `&before=${messagesToArchive[messagesToArchive.length - 1].id}`
+          : ''
+      }`;
+
+      const messagesResponse = await rateLimitedFetch(getMessagesUrl, {
+        headers: {
+          Authorization: `Bot ${process.env.DISCORD_TOKEN}`,
+          'Content-Type': 'application/json; charset=UTF-8',
+          'User-Agent': discordBotUserAgent,
+        },
+      });
+
+      if (!messagesResponse.ok) {
+        console.error(
+          `Failed to fetch messages: ${messagesResponse.status} ${messagesResponse.statusText}`
+        );
+        return;
+      }
+
+      const messages: Message[] = await messagesResponse.json();
+
+      if (messages.length < messageLimit) {
+        flag = false;
+      }
+
+      messagesToArchive.push(...messages);
+    } // End of while loop
+
+    // Build a Map of unique channel participants and get their guild nicknames
+    const channelParticipantsMap = new Map<
+      string,
+      { id: string; username: string; nickname: string | null }
+    >();
+
+    for (let index = 0; index < messagesToArchive.length; index++) {
+      const message = messagesToArchive[index];
+
+      if (!channelParticipantsMap.has(message.author.id)) {
+        channelParticipantsMap.set(message.author.id, {
+          id: message.author.id,
+          username: message.author.username,
+          nickname: null,
+        });
+      }
+    } // End of for loop
+
+    // Now fetch nicknames for each participant
+    for (const [userId, participantInfo] of channelParticipantsMap) {
+      const nicknameResponse = await rateLimitedFetch(
+        `${baseUrl}guilds/${guildID}/members/${userId}`,
+        {
+          headers: {
+            Authorization: `Bot ${process.env.DISCORD_TOKEN}`,
+            'Content-Type': 'application/json; charset=UTF-8',
+            'User-Agent': discordBotUserAgent,
+          },
+        }
+      );
+
+      if (!nicknameResponse.ok) {
+        console.error(
+          `Failed to fetch member info for nickname: ${nicknameResponse.status} ${nicknameResponse.statusText}`
+        );
+        return;
+      }
+
+      const memberInfo = await nicknameResponse.json();
+
+      // ToDo Delete debug logging when done
+      /* console.log('Raw memberInfo: ');
+      console.log(memberInfo);
+      console.log('Adding participant: ');
+      console.log({
+        id: message.author.id,
+        username: message.author.username,
+        nickname: memberInfo.nick || null,
+      }); */
+
+      channelParticipantsMap.set(userId, {
+        id: participantInfo.id,
+        username: participantInfo.username,
+        nickname: memberInfo.nick || null,
+      });
+    } // End of for loop to get nicknames
+
+    // Convert Map to Array for easier processing
+    const channelParticipantsArray = Array.from(channelParticipantsMap.values());
+
+    // Prepare the email content
+    messagesToArchive.sort(
+      (a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()
+    );
+
+    const emailTextContent = `Archive of Discord messages from channel ${channel.name} in server: ${guildInfo.name}
+
+Participants:
+${channelParticipantsArray
+  .map(
+    (participant) =>
+      `- ${participant.username} ${participant.nickname ? ` (${participant.nickname})` : ''}`
+  )
+  .join('\n')}
+
+Messages:
+${messagesToArchive
+  .map(
+    (msg) =>
+      `[${new Date(msg.timestamp).toUTCString()}] ${msg.author.username} ${channelParticipantsMap.get(msg.author.id)?.nickname ? ` (${channelParticipantsMap.get(msg.author.id)?.nickname})` : ''}: ${msg.content || ''}`
+  )
+  .join('\n')}
+
+END OF TRANSCRIPT
+
+This email was generated by the Scene Keeper Bot
+https://discord.com/oauth2/authorize?client_id=1416498066441109584
+`;
+
+    // Note: the .join('')} at the end of the map functions are needed to concatenate the array items into a single string.
+    const emailHtmlContent = `<html>
+  <body>
+    <h2>Archive of Discord messages from channel ${channel.name} in server: ${guildInfo.name}</h2>
+    <h3>Participants:</h3>
+    <ul style="border: 1px solid #000; padding: 10px; list-style-type: none;">
+      ${channelParticipantsArray
+        .map(
+          (participant) =>
+            `<li>${participant.username}${
+              participant.nickname ? ` (${participant.nickname})` : ''
+            }</li>`
+        )
+        .join('')}
+    </ul>
+    <h3>Messages:</h3>
+    <div style="border: 1px solid #000; padding: 10px; font-family: monospace;">
+${messagesToArchive
+  .map(
+    (msg) =>
+      `<div><p style="margin-bottom: 0px;">[${new Date(msg.timestamp).toUTCString()}] ${msg.author.username}${channelParticipantsMap.get(msg.author.id)?.nickname ? ` (${channelParticipantsMap.get(msg.author.id)?.nickname})` : ''}:</p> <p style="font-weight: bold; margin-top: 0px;">${msg.content || ''}</p></div>`
+  )
+  .join('')}
+    </div>
+    <footer>
+      <p>This email was generated by the Scene Keeper Bot.</p>
+    </footer>
+  </body>
+</html>`;
+
+    // Logic to email the archived messages goes here
+    const resend = new Resend(process.env.RESEND_API_KEY || 'missing_api_key');
+
+    const currentDate = new Date();
+    const formattedDate = `${currentDate.getFullYear()}-${(currentDate.getMonth() + 1)
+      .toString()
+      .padStart(2, '0')}-${currentDate.getDate().toString().padStart(2, '0')}`;
+
+    const { data, error } = await resend.emails.send({
+      from: 'Scene Keeper Bot <bot@scenekeeper.xyz>',
+      to: emailRecipients,
+      subject: `Archive of Discord Channel: ${channel.name} - ${formattedDate}`,
+      text: emailTextContent,
+      html: emailHtmlContent,
+    });
+
+    if (error) {
+      throw new Error(`Failed to send archive email: ${error.message}`);
+    }
+
+    // Send message to discord channel confirming archive sent
+    const confirmationResponse = await rateLimitedFetch(
+      `${baseUrl}channels/${channel.id}/messages`,
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Bot ${process.env.DISCORD_TOKEN}`,
+          'Content-Type': 'application/json; charset=UTF-8',
+          'User-Agent': discordBotUserAgent,
+        },
+        body: JSON.stringify({
+          content: `Archive email sent to: ${emailRecipients.join(', ')}.
+Total messages archived: ${messagesToArchive.length}.
+Once you have confirmed receipt of the archive email, you may wish to use the \`/clean\` command to clear non-pinned messages from this channel.`,
+        }),
+      }
+    );
+
+    if (!confirmationResponse.ok) {
+      console.error(
+        `Failed to send confirmation message: ${confirmationResponse.status} ${confirmationResponse.statusText}`
+      );
+      return;
+    }
+  } catch (error) {
+    console.error('Error archiving channel:', error);
+    // send notification to discord channel this was requested from
+  }
+}
+
+export { archiveChannel };

--- a/src/lib/cleanFunctions.ts
+++ b/src/lib/cleanFunctions.ts
@@ -1,68 +1,10 @@
-import packageJson from '../../package.json' with { type: 'json' };
-
 import type { Message } from '@/types/message.js';
+
+import packageJson from '../../package.json' with { type: 'json' };
+import { rateLimitedFetch } from './sharedFunctions.js';
 
 const baseUrl = 'https://discord.com/api/v10/';
 const discordBotUserAgent = `DiscordBot (https://github.com/jeffinnes/scene-keeper, ${packageJson.version})`;
-
-async function rateLimitedFetch(
-  url: string,
-  options?: RequestInit,
-  maxRetries: number = 3
-): Promise<Response> {
-  let retryCount = 0;
-
-  while (retryCount <= maxRetries) {
-    const response = await fetch(url, options);
-
-    // If not rate limited, return the response
-    if (response.status !== 429) {
-      return response;
-    }
-
-    // If we've hit the max retries, return the 429 response
-    if (retryCount >= maxRetries) {
-      console.error(`Max retries (${maxRetries}) exceeded for ${url}`);
-      return response;
-    }
-
-    // Handle rate limiting
-    let retryAfter = 1; // Default to 1 second if not specified
-
-    try {
-      // Check for retry_after in response headers first (Discord standard)
-      const retryAfterHeader = response.headers.get('retry-after');
-      if (retryAfterHeader) {
-        retryAfter = parseInt(retryAfterHeader, 10);
-      } else {
-        // Check response body for retry_after value
-        const responseBody = await response.text();
-        try {
-          const bodyJson = JSON.parse(responseBody);
-          if (bodyJson.retry_after) {
-            retryAfter = bodyJson.retry_after;
-          }
-        } catch {
-          // If parsing fails, use default retry time
-        }
-      }
-    } catch (error) {
-      console.warn('Failed to parse retry_after, using default delay:', error);
-    }
-
-    console.log(
-      `Rate limited (429). Retrying in ${retryAfter} seconds... (attempt ${retryCount + 1}/${maxRetries + 1})`
-    );
-
-    // Wait for the retry_after duration (convert to milliseconds)
-    await new Promise((resolve) => setTimeout(resolve, retryAfter * 1000));
-
-    retryCount++;
-  }
-
-  // This should never be reached due to the logic above, but TypeScript needs it
-  throw new Error('Unexpected error in rateLimitedFetch');
-}
 
 async function cleanChannel(
   channel: { id: string; name: string },
@@ -123,6 +65,7 @@ async function cleanChannel(
   console.log(`Total non-pinned messages to delete: ${messageIDs.length}`);
   console.log('Message IDs:', messageIDs);
 
+  // For testing/Debugging, just log the message IDs instead of deleting them.
   /* await rateLimitedFetch(`${baseUrl}channels/${channel.id}/messages`, {
     method: 'POST',
     headers: {

--- a/src/lib/cleanFunctions.ts
+++ b/src/lib/cleanFunctions.ts
@@ -15,14 +15,13 @@ async function cleanChannel(
     `Cleaning channel: ${channel.name} (ID: ${channel.id}) requested by user ${user.username}`
   );
 
-  const messageLimit = 2; // Discord API message limit per request
+  const messageLimit = 100; // Discord API message limit per request (100 max, set lower for debugging with low use channels)
 
   const messageIDs: string[] = [];
 
   let flag = true;
 
   while (flag === true) {
-    // Implementation for fetching and processing messages in batches
     // Fetch all the channel messages
     const getMessagesUrl = `${baseUrl}channels/${channel.id}/messages?limit=${messageLimit}${
       messageIDs.length > 0 ? `&before=${messageIDs[messageIDs.length - 1]}` : ''

--- a/src/lib/sharedFunctions.ts
+++ b/src/lib/sharedFunctions.ts
@@ -1,0 +1,63 @@
+/**
+ * A wrapper around fetch that handles rate limiting (HTTP 429) by retrying the request
+ * after the specified retry_after duration. It will retry up to maxRetries times before
+ * giving up and returning the 429 response.
+ */
+export async function rateLimitedFetch(
+  url: string,
+  options?: RequestInit,
+  maxRetries: number = 3
+): Promise<Response> {
+  let retryCount = 0;
+
+  while (retryCount <= maxRetries) {
+    const response = await fetch(url, options);
+
+    // If not rate limited, return the response
+    if (response.status !== 429) {
+      return response;
+    }
+
+    // If we've hit the max retries, return the 429 response
+    if (retryCount >= maxRetries) {
+      console.error(`Max retries (${maxRetries}) exceeded for ${url}`);
+      return response;
+    }
+
+    // Handle rate limiting
+    let retryAfter = 1; // Default to 1 second if not specified
+
+    try {
+      // Check for retry_after in response headers first (Discord standard)
+      const retryAfterHeader = response.headers.get('retry-after');
+      if (retryAfterHeader) {
+        retryAfter = parseInt(retryAfterHeader, 10);
+      } else {
+        // Check response body for retry_after value
+        const responseBody = await response.text();
+        try {
+          const bodyJson = JSON.parse(responseBody);
+          if (bodyJson.retry_after) {
+            retryAfter = bodyJson.retry_after;
+          }
+        } catch {
+          // If parsing fails, use default retry time
+        }
+      }
+    } catch (error) {
+      console.warn('Failed to parse retry_after, using default delay:', error);
+    }
+
+    console.log(
+      `Rate limited (429). Retrying in ${retryAfter} seconds... (attempt ${retryCount + 1}/${maxRetries + 1})`
+    );
+
+    // Wait for the retry_after duration (convert to milliseconds)
+    await new Promise((resolve) => setTimeout(resolve, retryAfter * 1000));
+
+    retryCount++;
+  }
+
+  // This should never be reached due to the logic above, but TypeScript needs it
+  throw new Error('Unexpected error in rateLimitedFetch');
+}

--- a/src/lib/sharedFunctions.ts
+++ b/src/lib/sharedFunctions.ts
@@ -3,7 +3,7 @@
  * after the specified retry_after duration. It will retry up to maxRetries times before
  * giving up and returning the 429 response.
  */
-export async function rateLimitedFetch(
+async function rateLimitedFetch(
   url: string,
   options?: RequestInit,
   maxRetries: number = 3
@@ -61,3 +61,5 @@ export async function rateLimitedFetch(
   // This should never be reached due to the logic above, but TypeScript needs it
   throw new Error('Unexpected error in rateLimitedFetch');
 }
+
+export { rateLimitedFetch };


### PR DESCRIPTION
## Changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Description

Adds the logic for users, with permissions to view messages, to call `/archive`. This will trigger the bot to email a transcript of all messages in a channel to the declared email addresses.

Resolves issue #4

## Testing

- [x] Commands tested in development server
- [x] No console errors
- [x] Permissions work as expected

